### PR TITLE
FLEX-544: inline-choice: guard width estimation against disconnected …

### DIFF
--- a/packages/interactions/inline-choice-interaction/src/qti-inline-choice-interaction.ts
+++ b/packages/interactions/inline-choice-interaction/src/qti-inline-choice-interaction.ts
@@ -105,6 +105,8 @@ export class QtiInlineChoiceInteraction extends Interaction {
     // Simple width estimation - no recalculation needed
     await this.updateComplete;
 
+    if (!this.isConnected) return;
+
     this.#estimateOptimalWidth();
   }
 
@@ -172,7 +174,7 @@ export class QtiInlineChoiceInteraction extends Interaction {
     const menu = this.#menuElement();
     const trigger = this.renderRoot.querySelector<HTMLElement>('button[part="trigger"]');
 
-    if (!menu || !trigger) return;
+    if (!menu || !trigger || !this.isConnected) return;
 
     // Find dropdown icon element inside the trigger
     const dropdownIcon = trigger.querySelector<HTMLElement>('span[part~="dropdown-icon"]');


### PR DESCRIPTION
connectedCallback awaits `updateComplete` and then runs a cosmetic
width-estimation pass that briefly calls `menu.showPopover()`. If the
element is unmounted during that await — e.g. fast item navigation in a
player — the popover is disconnected and showPopover() throws:

InvalidStateError: Failed to execute 'showPopover' on 'HTMLElement':
Invalid on disconnected popover elements.

Add `isConnected` guards after the await and at the top of
#estimateOptimalWidth (which is also reached synchronously from
#updateOptions and the MutationObserver callback). The estimation is
purely cosmetic, so skipping it on a disconnected element is safe.